### PR TITLE
remove @ symbol from path name

### DIFF
--- a/webfonts/_red-hat-font.scss
+++ b/webfonts/_red-hat-font.scss
@@ -38,7 +38,7 @@
 // No compiler? No problem! Paste this file into sassmeister.com
  
 // If you would like to load the font from static.redhat.com, use this variable 
-// $fontLocation: "https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts"; 
+// $fontLocation: "https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts"; 
 // and set the $relative argument to false when you call the mixin
  
 //----------------------

--- a/webfonts/red-hat-font.css
+++ b/webfonts/red-hat-font.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: "RedHatDisplay";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.svg#RedHatDisplay-Regular") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Regular.svg#RedHatDisplay-Regular") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 300;
@@ -10,9 +10,9 @@
 }
 @font-face {
   font-family: "RedHatDisplay";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.svg#RedHatDisplay-Medium") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Medium.svg#RedHatDisplay-Medium") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 400;
@@ -20,9 +20,9 @@
 }
 @font-face {
   font-family: "RedHatDisplay";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.svg#RedHatDisplay-Bold") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatDisplay/RedHatDisplay-Bold.svg#RedHatDisplay-Bold") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 700;
@@ -30,9 +30,9 @@
 }
 @font-face {
   font-family: "RedHatText";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.svg#RedHatDisplay-Regular") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.svg#RedHatDisplay-Regular") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 300;
@@ -40,9 +40,9 @@
 }
 @font-face {
   font-family: "RedHatText";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.svg#RedHatDisplay-Regular") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Regular.svg#RedHatDisplay-Regular") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 400;
@@ -50,9 +50,9 @@
 }
 @font-face {
   font-family: "RedHatText";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.svg#RedHatDisplay-Medium") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Medium.svg#RedHatDisplay-Medium") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 700;
@@ -60,9 +60,9 @@
 }
 @font-face {
   font-family: "RedHatText";
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.eot");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.eot");
   /* IE9 Compat Modes */
-  src: url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.woff") format("woff"), url("https://static.redhat.com/libs/@redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.svg#RedHatDisplay-Bold") format("svg");
+  src: url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.eot?#iefix") format("embedded-opentype"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.woff") format("woff"), url("https://static.redhat.com/libs/redhat/redhat-font/latest/webfonts/RedHatText/RedHatText-Bold.svg#RedHatDisplay-Bold") format("svg");
   /* Legacy iOS */
   font-style: "normal";
   font-weight: 900;


### PR DESCRIPTION
per Shawn's email, @ symbol has been removed from the path because it could get hairy/confusing:
`libs/%40redhat/`