### PR TITLE
Refresh metainfo files to account for the new "Red Hat Typeface" name and monospace font family

### DIFF
--- a/metainfo/com.redhat.redhat-display.metainfo.xml
+++ b/metainfo/com.redhat.redhat-display.metainfo.xml
@@ -6,7 +6,7 @@
   <name>Red Hat Display</name>
   <summary>Red Hat Display font family</summary>
   <description>
-    <p>Red Hat is a fresh take on the geometric sans genre,
+    <p>Red Hat Typeface is a fresh take on the geometric sans genre,
        taking inspiration from a range of American sans serifs
        including Tempo and Highway Gothic.
     </p>

--- a/metainfo/com.redhat.redhat-mono.metainfo.xml
+++ b/metainfo/com.redhat.redhat-mono.metainfo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="font">
+  <id>com.redhat.redhat-mono</id>
+  <project_license>OFL-1.1</project_license>
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <name>Red Hat Mono</name>
+  <summary>Red Hat Mono font family</summary>
+  <description>
+    <p>Red Hat Typeface is a fresh take on the geometric sans genre,
+       taking inspiration from a range of American sans serifs
+       including Tempo and Highway Gothic.
+    </p>
+    <p>The Mono styles are similar to the Text styles, but are adapted
+       for better performance to render code and similar text.
+    </p>
+    <p>The fonts were originally commissioned by Paula Scher / Pentagram
+       and designed by Jeremy Mickel / MCKL for the new Red Hat identity.
+    </p>
+  </description>
+  <update_contact>brand@redhat.com</update_contact>
+  <url type="homepage">https://github.com/RedHatOfficial/RedHatFont</url>
+</component>

--- a/metainfo/com.redhat.redhat-text.metainfo.xml
+++ b/metainfo/com.redhat.redhat-text.metainfo.xml
@@ -6,7 +6,7 @@
   <name>Red Hat Text</name>
   <summary>Red Hat Text font family</summary>
   <description>
-    <p>Red Hat is a fresh take on the geometric sans genre,
+    <p>Red Hat Typeface is a fresh take on the geometric sans genre,
        taking inspiration from a range of American sans serifs
        including Tempo and Highway Gothic.
     </p>


### PR DESCRIPTION
I'm working on updating `redhat-fonts` in Fedora and EPEL for version 4.0 and these are needed for that.