### PR TITLE
Homebrew 2.7.0 removed the cask subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note that Red Hat Enterprise Linux/CentOS users will need to [enable Fedora EPEL
 If you are running Homebrew, you can install the fonts with the following:
 
 ```text
-brew cask install homebrew/cask-fonts/font-redhat
+brew install homebrew/cask-fonts/font-redhat
 ```
 
 ## Bug reports and improvement requests


### PR DESCRIPTION
Update `README.md` as homebrew have changed the way casks are installed. 

For reference [homebrew 2.6.0](https://github.com/Homebrew/brew/releases/tag/2.6.0) deprecated the `cask` command and it was removed in 2.7.0. While the release notes for 2.6.0 mention using `brew install --cask ...` the need for the cask flag has been removed see the [homebrew-cask usage file](https://github.com/Homebrew/homebrew-cask/blob/master/USAGE.md#frequently-used-commands). 