### PR TITLE
remove unused homebrew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note that Red Hat Enterprise Linux/CentOS users will need to [enable Fedora EPEL
 If you are running Homebrew, you can install the fonts with the following:
 
 ```text
-brew cask install homebrew/cask-fonts/font-redhat
+brew install --cask homebrew/cask-fonts/font-redhat
 ```
 
 ## Bug reports and improvement requests


### PR DESCRIPTION
`brew cask` is no longer a `brew` command, you should use `brew install --cask` instead.