### PR TITLE
Fix deprecated CI runner, update actions, and fix README typos

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-18.04 machine.
+      # Checks out a copy of your repository on the runner.
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -24,7 +24,7 @@ jobs:
 
       # Deploy what's in ./webfonts-demo to github pages.
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./webfonts-demo

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cd woff2
 make clean all
 ```
 
-To make sure woff2_compress is installed properly, enter the following inyour terminal window:
+To make sure woff2_compress is installed properly, enter the following in your terminal window:
 
 ```
 woff2_compress
@@ -133,7 +133,7 @@ Note that Red Hat Enterprise Linux/CentOS users will need to [enable Fedora EPEL
 If you are running Homebrew, you can install the fonts with the following:
 
 ```text
-brew cask install homebrew/cask-fonts/font-redhat
+brew install --cask homebrew/cask-fonts/font-redhat
 ```
 
 ## Bug reports and improvement requests


### PR DESCRIPTION
## Summary

- **gh-pages.yml**: Replace removed `ubuntu-18.04` runner with `ubuntu-latest` (ubuntu-18.04 was removed from GitHub Actions in April 2023) and update `peaceiris/actions-gh-pages` from v3 to v4
- **README.md**: Fix "inyour" typo to "in your" (line 93)
- **README.md**: Update deprecated `brew cask install` to `brew install --cask` (the `cask` subcommand was removed in Homebrew 2.6.0)

## Verification

- Confirmed all patterns exist before editing via grep
- Diff reviewed for correctness