### PR TITLE
Fix broken build script reference in README and add build-all.sh (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are two versions of the variable fonts: with and without VF in the name. I
 
 ## Building the Fonts
 
-From terminal, run the build script at `sources/build-all.sh`. Fonts output to `fonts/`.
+From terminal, run the build script at `source/build-all.sh`. Fonts output to `fonts/`.
 
 NOTE: The first time you build, you will need to set up a virtual environment and install dependencies:
 
@@ -117,6 +117,8 @@ gftools builder source/Proportional/RedHatDisplay/config.yaml
 ```bash
 gftools builder source/Proportional/RedHatText/config.yaml
 ```
+
+To build all three families at once, run `source/build-all.sh`, which executes the commands above in sequence.
 
 
 ## Installation

--- a/source/build-all.sh
+++ b/source/build-all.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Build all Red Hat font families (Mono, Display, Text) from source.
+#
+# Prerequisites: activate the virtual environment and install the build
+# dependencies first (see the "Building the Fonts" section of README.md):
+#
+#   pip install -U -r requirements.txt
+#
+# Fonts are written to the fonts/ directory.
+
+set -euo pipefail
+
+# Run from the repository root regardless of where the script is invoked.
+cd "$(dirname "$0")/.."
+
+configs=(
+  "source/Mono/config.yaml"
+  "source/Proportional/RedHatDisplay/config.yaml"
+  "source/Proportional/RedHatText/config.yaml"
+)
+
+for config in "${configs[@]}"; do
+  echo "==> Building ${config}"
+  gftools builder "${config}"
+done
+
+echo "==> Done. Fonts output to fonts/"


### PR DESCRIPTION
## Summary
Addresses #15 (Instructions to build from source is missing).

The "Building the Fonts" section pointed to `sources/build-all.sh`, but that path doesn't exist — the sources live in `source/` (singular) and there was no `build-all.sh` script (a leftover from the old `source_files/`/`build.py` build system before the move to `gftools` + `config.yaml`).

This PR:
- Adds `source/build-all.sh`, a small wrapper that runs the three documented `gftools builder` commands (Mono, Display, Text) in sequence, so the README's headline instruction actually works.
- Fixes the README path `sources/build-all.sh` → `source/build-all.sh`.
- Adds a note in the "Build fonts" section pointing to the wrapper.

## Verification
- `bash -n source/build-all.sh` passes; script is marked executable.
- The wrapper runs exactly the `gftools builder` commands already documented in the README.

Note: I did not run a full font build end-to-end (requires the `afdko`/`fontmake`/`gftools` toolchain in a venv); the script wraps the repo's existing documented commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)