### PR TITLE
Halve Red Hat Mono underline thickness (#67)

### DIFF
--- a/source/Mono/RedHatMono-Italic.glyphs
+++ b/source/Mono/RedHatMono-Italic.glyphs
@@ -795,7 +795,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;
@@ -934,7 +934,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;
@@ -1072,7 +1072,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;

--- a/source/Mono/RedHatMono.glyphs
+++ b/source/Mono/RedHatMono.glyphs
@@ -770,7 +770,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;
@@ -908,7 +908,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;
@@ -1045,7 +1045,7 @@ value = 50;
 },
 {
 name = underlineThickness;
-value = 100;
+value = 50;
 },
 {
 name = underlinePosition;


### PR DESCRIPTION
## Summary
Fixes #67 — the dotted spellcheck error underline in gtksourceview renders much larger with Red Hat Mono than with comparable fonts.

**Cause:** Red Hat Mono sets `post.underlineThickness` to **100** (10% of the 1000 UPM) — twice the font's own `OS/2.yStrikeoutSize` (50), and about double a typical monospace value (Source Code Pro, which @chergert notes "looks fine," uses ~50). Pango draws error underlines at **3× the underline thickness** (`pango_renderer_draw_error_underline`), so the dots come out oversized.

**Fix:** set `underlineThickness` to **50** across all masters of `RedHatMono.glyphs` and `RedHatMono-Italic.glyphs` — matching the existing strikeout weight and roughly halving the rendered error-underline size. `underlinePosition` is left unchanged.

## Verification
Rebuilt Mono (roman + italic) with fontmake:
- `post.underlineThickness` is now 50 for all styles.
- All glyph outlines are **byte-identical** to the previous build (only the `post` metric changes).

Scoped to Red Hat Mono, the font in the report. Red Hat Text and Display carry the same value if the maintainers would like it applied there too. The exact target is of course a design call — 50 matches the strikeout weight and Source Code Pro, but feel free to tune it. Binaries should be regenerated from these sources on the next release build.
